### PR TITLE
Redesign CPPHooks class

### DIFF
--- a/cpp_plugin/cpp_hooks.py
+++ b/cpp_plugin/cpp_hooks.py
@@ -1,17 +1,13 @@
 import logging
-import ida_frame
-import ida_funcs
 import ida_idp
 import ida_struct
 import ida_xref
 import idautils
 import ida_typeinf
-import idaapi
 import idc
-import ida_hexrays
 
-import utils
-from utils import batchmode
+from .. import utils
+from ..utils import batchmode
 
 log = logging.getLogger("ida_medigate")
 
@@ -102,223 +98,260 @@ Function arg renamed in decompiler (N on the function arg):
 """
 
 
-@batchmode
-def post_func_name_change(new_name, ea):
-    xrefs = idautils.XrefsTo(ea, ida_xref.XREF_USER)
-    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
-    args_list = []
-    for xref in xrefs:
-        res = ida_struct.get_member_by_id(xref.frm)
-        if not res or not res[0]:
-            log.warning("Xref from %08X wasn't struct_member", xref.frm)
-            continue
-        # In IDA7.0 get_member_by_id() returns incorrect struct, which,
-        # when accessed, causes IDA to crash.
-        # In IDA7.5 SP3 get_member_by_id() returns correct struct.
-        # So it looks like an IDA bug.
-        # To avoid crashes, we get struct from the member's full name.
-        # This approach works both in IDA7.0 and IDA7.5 SP3
-        member = res[0]
-        struct = ida_struct.get_member_struc(ida_struct.get_member_fullname(member.id))
-        assert struct
-        args_list.append([struct, member.get_soff(), new_name])
-
-    return utils.set_member_name, args_list
+def enum_linked_members(funcea):
+    for xref in idautils.XrefsTo(funcea, ida_xref.XREF_USER):
+        if xref.user and xref.type == ida_xref.dr_I:
+            if ida_struct.is_member_id(xref.frm):
+                yield xref.frm
 
 
-def post_struct_member_name_change(member, new_name):
-    xrefs = idautils.XrefsFrom(member.id)
-    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
-    for xref in xrefs:
-        if utils.is_func_start(xref.to):
-            utils.set_func_name(xref.to, new_name)
+def has_linked_members(funcea):
+    return any(enum_linked_members(funcea))
 
 
-def post_struct_member_type_change(member):
-    xrefs = idautils.XrefsFrom(member.id)
-    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
-    for xref in xrefs:
-        if utils.is_func_start(xref.to):
-            member_tinfo = idaapi.tinfo_t()
-            ida_struct.get_member_tinfo(member_tinfo, member)
-            if member_tinfo.is_funcptr():
-                function_tinfo = member_tinfo.get_pointed_object()
-                if function_tinfo:
-                    if not ida_typeinf.apply_tinfo(xref.to, function_tinfo, idaapi.TINFO_DEFINITE):
-                        log.warn(
-                            "Failed to apply tinfo %s -> %s",
-                            ida_struct.get_member_fullname(member.id),
-                            idc.get_name(xref.to),
-                        )
+def enum_linked_funcs(mid):
+    for xref in idautils.XrefsFrom(mid, ida_xref.XREF_USER):
+        if xref.user and xref.type == ida_xref.dr_I:
+            if utils.is_func_start(xref.to):
+                yield xref.to
 
 
-@batchmode
-def post_func_type_change(funcea):
-    xrefs = idautils.XrefsTo(funcea, ida_xref.XREF_USER)
-    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
-    args_list = []
-    if not xrefs:
-        return None, []
-    try:
-        xfunc = ida_hexrays.decompile(funcea)
-        func_ptr_typeinf = utils.get_typeinf_ptr(xfunc.type)
-        for xref in xrefs:
-            res = ida_struct.get_member_by_id(xref.frm)
-            if not res or not res[0]:
-                log.warning("Can't get struct for member %08X", xref.frm)
-                continue
-            member = res[0]
-            struct = ida_struct.get_member_struc(ida_struct.get_member_fullname(member.id))
-            assert struct
-            args_list.append([struct, member, 0, func_ptr_typeinf, idaapi.TINFO_DEFINITE])
-    except ida_hexrays.DecompilationFailure:
-        # TODO: get func type even if decompilation fails
-        pass
-    return ida_struct.set_member_tinfo, args_list
+def has_linked_funcs(mid):
+    return any(enum_linked_funcs(mid))
 
 
-def rename_struct_member(mid, new_name):
+def rename_linked_member(mid, new_name):
+    member_full_name = ida_struct.get_member_fullname(mid)
     if ida_struct.get_member_name(mid) == new_name:
+        log.debug(
+            "%08X %s: linked member already has name '%s'",
+            mid,
+            member_full_name,
+            new_name,
+        )
         return
-    mptr = utils.get_mptr_by_id(mid)
-    if not mptr or ida_struct.is_special_member(mptr.id):
+    if ida_struct.is_special_member(mid):
         # special member with the name beginning with ' '?
+        log.warn("%08X %s: linked member is a special member", mid, member_full_name)
         return
-    sptr = utils.get_sptr_by_member_id(mptr.id)
-    if not sptr or sptr.is_frame():
-        # member is the arg field in function frame
+    sptr = utils.get_sptr_by_member_id(mid)
+    if not sptr:
+        log.warn("%08X: failed to get linked member sptr", mid)
+        return
+    if sptr.is_frame():
+        log.warn(
+            "%08X %s: linked member is an arg in function frame",
+            mid,
+            ida_struct.get_member_name(mid),
+        )
+        return
+    mptr = utils.get_mptr_by_member_id(mid)
+    if not mptr:
+        log.warn("%08X: failed to get linked member mptr", mid)
         return
     if not ida_struct.set_member_name(sptr, mptr.get_soff(), new_name):
         log.warn(
-            "Couldn't rename struct member %08X from '%s' to '%s'",
-            mptr.id,
-            ida_struct.get_member_name(mptr.id),
+            "%08X %s: failed to rename linked member to '%s'",
+            mid,
+            member_full_name,
             new_name,
         )
+        return
+    log.debug("%08X %s: renamed linked member to '%s'", mid, member_full_name, new_name)
+
+
+def rename_linked_func(funcea, new_name):
+    # TODO: replace "__" with "::" in new_name?
+    func_name = idc.get_name(funcea)
+    if idc.get_name(funcea) == new_name:
+        log.debug("%08X %s: linked func already has name '%s'", funcea, func_name, new_name)
+        return
+    if not idc.set_name(funcea, new_name):
+        log.warn(
+            "%08X %s: failed to rename linked func to '%s'",
+            funcea,
+            func_name,
+            new_name,
+        )
+        return
+    log.debug("%08X %s: renamed linked func to '%s'", funcea, func_name, new_name)
+
+
+def change_linked_member_type(mid, new_member_tif):
+    member_full_name = ida_struct.get_member_fullname(mid)
+    if idc.get_tinfo(mid) == new_member_tif.serialize()[:-1]:
+        log.debug(
+            "%08X %s: linked member already has type %s",
+            mid,
+            member_full_name,
+            new_member_tif,
+        )
+        return
+    mptr, _, sptr = utils.get_member_by_id(mid)
+    smt_code = ida_struct.set_member_tinfo(
+        sptr, mptr, 0, new_member_tif, ida_typeinf.TINFO_DEFINITE
+    )
+    if smt_code != ida_struct.SMT_OK:
+        log.warn(
+            "%08X %s: failed to change linked member type to %s: %s",
+            mid,
+            member_full_name,
+            new_member_tif,
+            utils.print_smt_code(smt_code),
+        )
+        return
+    log.debug(
+        "%08X %s: changed linked member type to %s",
+        mid,
+        member_full_name,
+        new_member_tif,
+    )
+
+
+def change_linked_func_type(funcea, new_func_tif):
+    func_name = idc.get_name(funcea)
+    if idc.get_tinfo(funcea) == new_func_tif.serialize()[:-1]:
+        log.debug("%08X %s: linked func already has type %s", funcea, func_name, new_func_tif)
+        return
+    if not ida_typeinf.apply_tinfo(funcea, new_func_tif, ida_typeinf.TINFO_DEFINITE):
+        log.warn(
+            "%08X %s: failed to change linked func type to %s",
+            funcea,
+            func_name,
+            new_func_tif,
+        )
+        return
+    log.debug("%08X %s: changed linked func type to %s", funcea, func_name, new_func_tif)
 
 
 @batchmode
 def rename_linked_members(funcea, new_name):
-    for xref in idautils.XrefsTo(funcea, ida_xref.XREF_USER):
-        if xref.user and xref.type == ida_xref.dr_I:
-            if not ida_struct.is_member_id(xref.frm):
-                continue
-            if ida_struct.get_member_name(xref.frm) == new_name:
-                continue
-            rename_struct_member(xref.frm, new_name)
+    # TODO: replace "::" with "__" in new_name?
+    for mid in enum_linked_members(funcea):
+        rename_linked_member(mid, new_name)
 
 
-def rename_func(funcea, new_name):
-    if idc.get_name(funcea) == new_name:
-        return
-    if not idc.set_name(funcea, new_name):
-        log.warn(
-            "Couldn't rename func at %08X from '%s' to '%s'",
-            funcea,
-            idc.get_name(funcea),
-            new_name,
-        )
+@batchmode
+def change_linked_members_type(funcea, new_func_tif):
+    assert new_func_tif.is_func()
+    new_member_tif = utils.get_typeinf_ptr(new_func_tif)
+    assert new_member_tif.is_funcptr()
+    for mid in enum_linked_members(funcea):
+        change_linked_member_type(mid, new_member_tif)
 
 
 def rename_linked_funcs(mid, new_name):
     # there should be only one such func
-    # maybe we should put assertion for that
-    for xref in idautils.XrefsFrom(mid, ida_xref.XREF_USER):
-        if xref.user and xref.type == ida_xref.dr_I:
-            if not utils.is_func_start(xref.to):
-                continue
-            if idc.get_name(xref.to) == new_name:
-                continue
-            rename_func(xref.to, new_name)
+    linked_funcs = list(enum_linked_funcs(mid))
+    assert len(linked_funcs) == 1, "vtable member points to more than one func"
+    funcea = linked_funcs[0]
+    rename_linked_func(funcea, new_name)
 
 
-class CPPHooks2(ida_idp.IDB_Hooks):
-    def __init__(self, is_decompiler_on):
-        self.is_decompiler_on = is_decompiler_on
+def change_linked_funcs_type(mid, new_member_tif):
+    assert new_member_tif.is_funcptr()
+    new_func_tif = utils.deref_tinfo(new_member_tif)
+    assert new_func_tif.is_func()
+    linked_funcs = list(enum_linked_funcs(mid))
+    assert len(linked_funcs) == 1, "vtable member points to more than one func"
+    funcea = linked_funcs[0]
+    change_linked_func_type(funcea, new_func_tif)
 
+
+class CPPHooks(ida_idp.IDB_Hooks):
     def struc_member_renamed(self, sptr, mptr):
         if sptr.is_frame():
             # function argument was renamed, not interested
             return 0
+        member_tif = utils.get_member_tinfo(mptr)
+        if not member_tif:
+            log.warn("%08X: failed to get member tinfo", mptr.id)
+            return 0
+        if not member_tif.is_funcptr():
+            return 0
+        if not has_linked_funcs(mptr.id):
+            return 0
         new_name = ida_struct.get_member_name(mptr.id)
+        if not new_name:
+            log.warn("%08X: failed to get member name", mptr.id)
+            return
+        log.debug(
+            "%08X %s: member renamed to '%s', renaming linked func",
+            mptr.id,
+            ida_struct.get_member_fullname(mptr.id),
+            new_name,
+        )
         rename_linked_funcs(mptr.id, new_name)
         return 0
-
-    def func_renamed(self, funcea, new_name):
-        self.unhook()
-        try:
-            rename_linked_members(funcea, new_name)
-        finally:
-            self.hook()
 
     def renamed(self, ea, new_name, local_name):
         # This event happens when anything is renamed,
         # including struct members and function arguments.
         # Here we only interested if function was renamed.
         # And for struct members we have separate event handler.
-        if utils.is_func_start(ea):
-            self.func_renamed(ea, new_name)
-        return 0
-
-
-class CPPHooks(ida_idp.IDB_Hooks):
-    def __init__(self, is_decompiler_on):
-        super(CPPHooks, self).__init__()
-        self.is_decompiler_on = is_decompiler_on
-
-    def renamed(self, ea, new_name, local_name):
-        # Called both for func and field renames AFTER name was successfully set
-        if utils.is_func_start(ea):
-            func, args_list = post_func_name_change(new_name, ea)
-            self.unhook()
-            for args in args_list:
-                func(*args)
+        if not utils.is_func_start(ea):
+            return 0
+        if not has_linked_members(ea):
+            return 0
+        log.debug("%08X: func renamed to '%s', renaming linked members", ea, new_name)
+        self.unhook()
+        try:
+            rename_linked_members(ea, new_name)
+        finally:
             self.hook()
         return 0
 
-    def func_updated(self, pfn):
-        # This only called when user updates func type (weather it actually updated or not, doesn't matter)
-        # It is not called when function is renamed, both in IDA7.0 and 7.5
-        funcea = pfn.start_ea
-        func, args_list = post_func_type_change(funcea)
-        self.unhook()
-        for args in args_list:
-            func(*args)
-        self.hook()
-        return 0
-
-    def renaming_struc_member(self, sptr, mptr, newname):
-        if sptr.is_frame():
-            return 0
-        # FIXME: should not post here, because the name might be bad and never actually change
-        # For example if such name already exists, this hook will be called, then error about
-        # duplicate name will be shown, and name will not be actually changed
-        # TODO: move to renamed
-        post_struct_member_name_change(mptr, newname)
-        return 0
-
-    def struc_member_changed(self, sptr, mptr):
-        # FIXME: due to the bug in IDA7.0 the actual type of mptr has not changed yet, when this hook is being called
-        # TODO: move to ti_changed
-        post_struct_member_type_change(mptr)
-        return 0
-
     def ti_changed(self, ea, type, fnames):
-        if self.is_decompiler_on:
-            res = ida_struct.get_member_by_id(ea)
-            if res and res[0]:
-                member = res[0]
-                struct = ida_struct.get_member_struc(ida_struct.get_member_fullname(member.id))
-                assert struct
-                if struct.is_frame():
-                    # func_updated does not get called if you rename single arg in decompiler,
-                    # so we need to call it manually here
-                    func = ida_funcs.get_func(ida_frame.get_func_by_frame(struct.id))
-                    if not func:
-                        log.warning("Couldn't get func by frame 0x%X", struct.id)
-                        return 0
-                    return self.func_updated(func)
-            elif utils.is_func_start(ea):
-                # FIXME: no need to call it manually, IDA will do it herself
-                return self.func_updated(ida_funcs.get_func(ea))
+        if utils.is_func_start(ea):
+            self._func_type_changed(ea, type, fnames)
+        elif ida_struct.is_member_id(ea):
+            self._struc_member_type_changed(ea, type, fnames)
         return 0
+
+    def _func_type_changed(self, funcea, type, fnames):
+        assert utils.is_func_start(funcea)
+        if not has_linked_members(funcea):
+            return
+        func_name = idc.get_name(funcea)
+        new_tif = utils.deserialize_typeinf(type, fnames)
+        if not new_tif:
+            logging.warn("%08X %s: failed to deserialize func type", funcea, func_name)
+            return
+        log.debug(
+            "%08X %s: func type changed to %s, updating linked members type",
+            funcea,
+            func_name,
+            new_tif,
+        )
+        self.unhook()
+        try:
+            change_linked_members_type(funcea, new_tif)
+        finally:
+            self.hook()
+
+    def _struc_member_type_changed(self, mid, type, fnames):
+        assert ida_struct.is_member_id(mid)
+        sptr = utils.get_sptr_by_member_id(mid)
+        if sptr.is_frame():
+            # Func arg type or name has changed and this ti_change() relates to the
+            # changed argument itself. We are not interested in it.
+            # There will be a separate ti_changed() for the whole function.
+            return
+        new_member_tif = utils.deserialize_typeinf(type, fnames)
+        if not new_member_tif:
+            logging.warn(
+                "%08X %s: failed to deserialize member type"
+                % (mid, ida_struct.get_member_fullname(mid))
+            )
+            return
+        if not new_member_tif.is_funcptr():
+            return
+        if not has_linked_funcs(mid):
+            return
+        log.debug(
+            "%08X %s: member type changed to %s, updating linked func type",
+            mid,
+            ida_struct.get_member_fullname(mid),
+            new_member_tif,
+        )
+        change_linked_funcs_type(mid, new_member_tif)

--- a/cpp_plugin/cpp_hooks.py
+++ b/cpp_plugin/cpp_hooks.py
@@ -3,55 +3,146 @@ import ida_frame
 import ida_funcs
 import ida_idp
 import ida_struct
-from .. import cpp_utils, utils
+import ida_xref
+import idautils
+import ida_typeinf
+import idaapi
+import idc
+import ida_hexrays
+
+import utils
+from utils import batchmode
 
 log = logging.getLogger("ida_medigate")
 
 
 """
-Function renamed:
-    IDA7.0:
-        renamed
-    IDA7.5 SP3:
-        renamed
+IDA7.0 bugs
 
-Function type changed (Y on the whole function):
+ida_struct.get_member_by_id()  @return: tuple(mptr, member_fullname, sptr)
     IDA7.0:
-        ti_changed
-        func_udpated
-        for each arg in function frame:
-            renaming_struc_member
+        sptr points to some wrong struct. Attempts to access this struct lead to IDA crash
+    In IDA7.5 SP3:
+        sptr points to a proper struct
+
+IDB_Hooks
+    Function renamed:
+        IDA7.0:
             renamed
-    IDA7.5 SP3:
-        (the same)
+        IDA7.5 SP3:
+            renamed
 
-Function arg renamed or type changed (Y on the function arg):
-    IDA7.0:
-        ti_changed (function)
-        func_udpated
-    IDA7.5 SP3:
-        (the same)
-        + sometimes (unpredictable) there might also be the following events:
-            ti_changed (arg)
-            renaming_struc_member (arg)
-            renamed (arg)
+    Function type changed (Y on the whole function):
+        IDA7.0:
+            ti_changed
+            func_udpated
+            for each arg in function frame:
+                renaming_struc_member
+                renamed
+        IDA7.5 SP3:
+            (the same)
 
-Structure member renamed:
-    IDA7.0:
-        renaming_struc_member
-        renamed (only happens if name was successfully set)
-    IDA7.5 SP3:
-        (the same)
+    Function arg renamed or type changed (Y on the function arg):
+        IDA7.0:
+            ti_changed (function)
+            func_udpated
+        IDA7.5 SP3:
+            (the same)
+            + sometimes (unpredictable) there might also be the following events:
+                ti_changed (arg)
+                renaming_struc_member (arg)
+                renamed (arg)
 
-Structure member type changed:
-    IDA7.0:
-        struct_member_changed (member tinfo = OLD type!) (seems like a bug in IDA7.0)
-        ti_changed (member tinfo = NEW type)
-    IDA7.5 SP3:
-        ti_changed (member tinfo = NEW type)
-        struct_member_changed (member tinfo = NEW type)
+    Structure member renamed:
+        IDA7.0:
+            renaming_struc_member
+            renamed (only happens if name was successfully set)
+        IDA7.5 SP3:
+            (the same)
 
+    Structure member type changed:
+        IDA7.0:
+            struct_member_changed (member tinfo = OLD type!) (seems like a bug in IDA7.0)
+            ti_changed (member tinfo = NEW type)
+        IDA7.5 SP3:
+            ti_changed (member tinfo = NEW type)
+            struct_member_changed (member tinfo = NEW type)
 """
+
+
+@batchmode
+def post_func_name_change(new_name, ea):
+    xrefs = idautils.XrefsTo(ea, ida_xref.XREF_USER)
+    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
+    args_list = []
+    for xref in xrefs:
+        res = ida_struct.get_member_by_id(xref.frm)
+        if not res or not res[0]:
+            log.warning("Xref from %08X wasn't struct_member", xref.frm)
+            continue
+        # In IDA7.0 get_member_by_id() returns incorrect struct, which,
+        # when accessed, causes IDA to crash.
+        # In IDA7.5 SP3 get_member_by_id() returns correct struct.
+        # So it looks like an IDA bug.
+        # To avoid crashes, we get struct from the member's full name.
+        # This approach works both in IDA7.0 and IDA7.5 SP3
+        member = res[0]
+        struct = ida_struct.get_member_struc(ida_struct.get_member_fullname(member.id))
+        assert struct
+        args_list.append([struct, member.get_soff(), new_name])
+
+    return utils.set_member_name, args_list
+
+
+def post_struct_member_name_change(member, new_name):
+    xrefs = idautils.XrefsFrom(member.id)
+    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
+    for xref in xrefs:
+        if utils.is_func_start(xref.to):
+            utils.set_func_name(xref.to, new_name)
+
+
+def post_struct_member_type_change(member):
+    xrefs = idautils.XrefsFrom(member.id)
+    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
+    for xref in xrefs:
+        if utils.is_func_start(xref.to):
+            member_tinfo = idaapi.tinfo_t()
+            ida_struct.get_member_tinfo(member_tinfo, member)
+            if member_tinfo.is_funcptr():
+                function_tinfo = member_tinfo.get_pointed_object()
+                if function_tinfo:
+                    if not ida_typeinf.apply_tinfo(xref.to, function_tinfo, idaapi.TINFO_DEFINITE):
+                        log.warn(
+                            "Failed to apply tinfo %s -> %s",
+                            ida_struct.get_member_fullname(member.id),
+                            idc.get_name(xref.to),
+                        )
+
+
+@batchmode
+def post_func_type_change(funcea):
+    xrefs = idautils.XrefsTo(funcea, ida_xref.XREF_USER)
+    xrefs = [xref for xref in xrefs if xref.type == ida_xref.dr_I and xref.user == 1]
+    args_list = []
+    if not xrefs:
+        return None, []
+    try:
+        xfunc = ida_hexrays.decompile(funcea)
+        func_ptr_typeinf = utils.get_typeinf_ptr(xfunc.type)
+        for xref in xrefs:
+            res = ida_struct.get_member_by_id(xref.frm)
+            if not res or not res[0]:
+                log.warning("Can't get struct for member %08X", xref.frm)
+                continue
+            member = res[0]
+            struct = ida_struct.get_member_struc(ida_struct.get_member_fullname(member.id))
+            assert struct
+            args_list.append([struct, member, 0, func_ptr_typeinf, idaapi.TINFO_DEFINITE])
+    except ida_hexrays.DecompilationFailure:
+        # TODO: get func type even if decompilation fails
+        pass
+    return ida_struct.set_member_tinfo, args_list
 
 
 class CPPHooks(ida_idp.IDB_Hooks):
@@ -62,7 +153,7 @@ class CPPHooks(ida_idp.IDB_Hooks):
     def renamed(self, ea, new_name, local_name):
         # Called both for func and field renames AFTER name was successfully set
         if utils.is_func_start(ea):
-            func, args_list = cpp_utils.post_func_name_change(new_name, ea)
+            func, args_list = post_func_name_change(new_name, ea)
             self.unhook()
             for args in args_list:
                 func(*args)
@@ -73,7 +164,7 @@ class CPPHooks(ida_idp.IDB_Hooks):
         # This only called when user updates func type (weather it actually updated or not, doesn't matter)
         # It is not called when function is renamed, both in IDA7.0 and 7.5
         funcea = pfn.start_ea
-        func, args_list = cpp_utils.post_func_type_change(funcea)
+        func, args_list = post_func_type_change(funcea)
         self.unhook()
         for args in args_list:
             func(*args)
@@ -84,16 +175,16 @@ class CPPHooks(ida_idp.IDB_Hooks):
         if sptr.is_frame():
             return 0
         # FIXME: should not post here, because the name might be bad and never actually change
-        # For example if such name already exists, this hook will be called, then error about 
+        # For example if such name already exists, this hook will be called, then error about
         # duplicate name will be shown, and name will not be actually changed
         # TODO: move to renamed
-        cpp_utils.post_struct_member_name_change(mptr, newname)
+        post_struct_member_name_change(mptr, newname)
         return 0
 
     def struc_member_changed(self, sptr, mptr):
         # FIXME: due to the bug in IDA7.0 the actual type of mptr has not changed yet, when this hook is being called
         # TODO: move to ti_changed
-        cpp_utils.post_struct_member_type_change(mptr)
+        post_struct_member_type_change(mptr)
         return 0
 
     def ti_changed(self, ea, type, fnames):

--- a/cpp_plugin/plugin.py
+++ b/cpp_plugin/plugin.py
@@ -21,7 +21,7 @@ class CPPPlugin(ida_idaapi.plugin_t):
     """
 
     # Mandatory definitions
-    PLUGIN_NAME = "ida_cpp"
+    PLUGIN_NAME = "ida_medigate"
     PLUGIN_VERSION = "0.0.1"
     PLUGIN_AUTHORS = "Medigate"
     TOGGLE_HOTKEY = "CTRL+ALT+SHIFT-M"

--- a/cpp_plugin/plugin.py
+++ b/cpp_plugin/plugin.py
@@ -49,7 +49,7 @@ class CPPPlugin(ida_idaapi.plugin_t):
         else:
             log.warn("Hex-Rays decompiler is not available")
 
-        self.cpp_hooks = CPPHooks(self.is_decompiler_on)
+        self.cpp_hooks = CPPHooks()
         self.gui_hooks = CPPUIHooks()
 
         if not self.hook():

--- a/utils.py
+++ b/utils.py
@@ -85,6 +85,18 @@ def is_func_start(ea):
     return func is not None and func.start_ea == ea
 
 
+def is_func(ea):
+    func = ida_funcs.get_func(ea)
+    return func is not None
+
+
+def get_func_start(ea):
+    func = ida_funcs.get_func(ea)
+    if not func:
+        return BADADDR
+    return func.start_ea
+
+
 def get_funcs_list():
     raise Exception("Not implemented")
 
@@ -288,6 +300,20 @@ def get_member_tinfo(member):
         log.warn("Couldn't get member type info")
         return None
     return member_typeinf
+
+
+def get_mptr_by_id(mid):
+    res = ida_struct.get_member_by_id(mid)
+    if not res:
+        return None
+    return res[0]
+
+
+def get_sptr_by_member_id(mid):
+    mptr = get_mptr_by_id(mid)
+    if not mptr:
+        return None
+    return ida_struct.get_member_struc(ida_struct.get_member_fullname(mptr.id))
 
 
 def get_sptr_by_name(struct_name):


### PR DESCRIPTION
### Tasks
- [x] Understand better and describe inner workings of IDA hooking API
- [x] Remove unnecessary hooks
- [x] Simplify CPPHooks class structure
- [x] Move all the code related to CPPHooks (post functions) from cpp_utils to cpp_hooks and basically get rid of them