### PR TITLE
Fix IDA7.0 (and IDA7.5 SP3) crash when deleting type

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -140,6 +140,11 @@ def get_typeinf(typestr):
 
 
 def deserialize_typeinf(xtype, fields):
+    # tif.deserialize(None, xtype, None) is fine
+    # tif.deserialize(None, None, fields) returns None
+    # tif.deserialize(None, None, None) crashes IDA (tested on IDA7.0 and IDA7.5 SP3)
+    if xtype is None:
+        return None
     tif = ida_typeinf.tinfo_t()
     if not tif.deserialize(None, xtype, fields):
         return None


### PR DESCRIPTION
When type is deleted ti_changed() event is received with both type, and nfields are None. and calling tinfo_t.deserialize(None, None, None) crashes IDA (all versions). So I just added check if type is None in utils.deserialize_typeinf(). This fixed the crashes.