### PR TITLE
Enhance make_vtable()

### DIFF
--- a/cpp_utils.py
+++ b/cpp_utils.py
@@ -286,19 +286,13 @@ def update_func_name_with_class(func_ea, class_name):
 
 
 def update_func_this(func_ea, this_type=None):
-    functype = None
-    try:
-        func_details = utils.get_func_details(func_ea)
-        if func_details is None:
-            return None
-        if this_type:
-            if func_details:
-                func_details[0].name = "this"
-                func_details[0].type = this_type
-        functype = utils.update_func_details(func_ea, func_details)
-    except ida_hexrays.DecompilationFailure as ex:
-        log.exception("Couldn't decompile func at %08X: %s", func_ea, ex)
-    return functype
+    func_details = utils.get_func_details(func_ea)
+    if func_details is None:
+        return None
+    if this_type and func_details.cc == idaapi.CM_CC_THISCALL and func_details:
+        func_details[0].name = "this"
+        func_details[0].type = this_type
+    return utils.update_func_details(func_ea, func_details)
 
 
 def add_class_vtable(struct_ptr, vtable_name, offset=BADADDR, vtable_field_name=None):

--- a/cpp_utils.py
+++ b/cpp_utils.py
@@ -336,6 +336,8 @@ def update_vtable_struct(
     pure_virtual_name=None,
     parent_name=None,
     add_func_this=True,
+    force_rename_vtable_head=False,  # rename vtable head even if it is already named by IDA
+    # if it's not named, then it will be renamed anyway
 ):
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     # TODO: refactor
@@ -393,16 +395,17 @@ def update_vtable_struct(
         vtable_head = functions_ea
     ida_bytes.del_items(vtable_head, ida_bytes.DELIT_SIMPLE, vtable_size)
     ida_bytes.create_struct(vtable_head, vtable_size, vtable_struct.id)
-    if parent_name is None and this_type:
-        parent = utils.deref_struct_from_tinfo(this_type)
-        parent_name = ida_struct.get_struc_name(parent.id)
-        if parent_name == class_name:
-            parent_name = None
-    idc.set_name(
-        vtable_head,
-        get_vtable_instance_name(class_name, parent_name),
-        ida_name.SN_CHECK | ida_name.SN_FORCE,
-    )
+    if not idc.hasUserName(idc.get_full_flags(vtable_head)) or force_rename_vtable_head:
+        if parent_name is None and this_type:
+            parent = utils.deref_struct_from_tinfo(this_type)
+            parent_name = ida_struct.get_struc_name(parent.id)
+            if parent_name == class_name:
+                parent_name = None
+        idc.set_name(
+            vtable_head,
+            get_vtable_instance_name(class_name, parent_name),
+            ida_name.SN_CHECK | ida_name.SN_FORCE,
+        )
 
 
 def is_valid_func_char(c):

--- a/utils.py
+++ b/utils.py
@@ -199,7 +199,7 @@ def get_func_details(func_ea):
     if not ida_nalt.get_tinfo(tif):
         log.warn("%08X Couldn't get func tinfo", func_ea)
         return None
-    if not tif.get_tinfo_details(func_details):
+    if not tif.get_func_details(func_details):
         log.warn("%08X Couldn't get func type details", func_ea)
         return None
     return func_details

--- a/utils.py
+++ b/utils.py
@@ -232,7 +232,7 @@ def update_func_details(func_ea, func_details):
     if not function_tinfo.create_func(func_details):
         log.warning("%08X Couldn't create func from details", func_ea)
         return None
-    if not ida_typeinf.apply_tinfo(func_ea, function_tinfo, idaapi.TINFO_DEFINITE):
+    if not ida_typeinf.apply_tinfo(func_ea, function_tinfo, idaapi.TINFO_GUESSED):
         log.warning("%08X Couldn't apply func tinfo", func_ea)
         return None
     return function_tinfo

--- a/utils.py
+++ b/utils.py
@@ -185,12 +185,22 @@ def create_funcptr(py_type):
 
 
 def get_func_details(func_ea):
-    xfunc = ida_hexrays.decompile(func_ea)
-    if xfunc is None:
-        return None
     func_details = idaapi.func_type_data_t()
-    if not xfunc.type.get_func_details(func_details):
-        log.warning("%08X Couldn't get func type details", func_ea)
+    try:
+        xfunc = ida_hexrays.decompile(func_ea)
+        if not xfunc.type.get_func_details(func_details):
+            log.warning("%08X Couldn't get func type details", func_ea)
+            return None
+        return func_details
+    except ida_hexrays.DecompilationFailure as ex:
+        log.exception("Couldn't decompile func at %08X: %s", func_ea, ex)
+
+    tif = ida_typeinf.tinfo_t()
+    if not ida_nalt.get_tinfo(tif):
+        log.warn("%08X Couldn't get func tinfo", func_ea)
+        return None
+    if not tif.get_tinfo_details(func_details):
+        log.warn("%08X Couldn't get func type details", func_ea)
         return None
     return func_details
 


### PR DESCRIPTION
### Tasks
- [x] vtable head should be renamed only if it is not yet named by IDA, unless force_rename_vtable_head is True
- [x] Function type should applied as GUESSED, rather then DEFINITE, to let IDA continue guessing type during further decompilation. This is especially useful for function that are not yet marked as __thiscall.
- [x] Function type details should be retrieved even if decompilation fails for a particular function.